### PR TITLE
more robust handling of references and fixes for messageContainer.hasDescendant and messageContainer.getSpecificChild

### DIFF
--- a/jwz.js
+++ b/jwz.js
@@ -51,7 +51,7 @@
         _.each(instance.children, function(child) {
           var found = child.getSpecificChild(id);
           if (found) {
-            specificChild = child;
+            specificChild = found;
             return;
           }
         })
@@ -89,7 +89,7 @@
         if (this.children.length < 1) return false;
         var descendantPresent = false;
         _.each(this.children, function(child) {
-          if(hasDescendant(child)) descendantPresent = true;
+          if(child.hasDescendant(container)) descendantPresent = true;
         })
         return descendantPresent;
       }

--- a/jwz.js
+++ b/jwz.js
@@ -156,7 +156,11 @@
           var parentContainer = getContainer(message.id);
           parentContainer.message = message;
           var prev = null;
-          _.each(message.references, function(reference) {
+          var references = message.references || [];
+          if (typeof(references) == 'string') {
+            references = [references]
+          }
+          _.each(references, function(reference) {
             var container = getContainer(reference);
             if (prev && !_.include(_.keys(container), "parent") && !container.hasDescendant(prev)) {
               prev.addChild(container);

--- a/jwz_test.js
+++ b/jwz_test.js
@@ -576,6 +576,10 @@ it("c").equal(root.children[0].children[0].children[0].message.id);
 it("d").equal(root.children[0].children[0].children[0].children[0].message.id);
 it("e").equal(root.children[0].children[0].children[0].children[0].children[0].message.id);
 
+// ensure getContainer and hasDescendant are working as expected
+it(root.getSpecificChild("e").message.references).deepEqual(["d"])
+it(root.hasDescendant(root.getSpecificChild("e"))).equal(true)
+
 //
 // (dummy in place of "a")
 // +- b


### PR DESCRIPTION
message.references is sometimes just a string (like '<parentMessageId>') rather than an array of ancestor ids. It's best to tolerate this case and tolerate undefined while we're at it.

Also, hasDescendant and getSpecificChild had small errors that made them incorrect.

After these fixes the test suite runs quietly again. I added tests for the messageContainer fixes.
